### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base install from node
-FROM node:latest
+FROM node:18.20-bookworm
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Base install from node
+FROM node:latest
+
+WORKDIR /app
+
+# apt update to install xdg-utils to avoid error during install
+RUN apt update && apt install -y xdg-utils
+
+# Download the install script
+RUN curl -O https://raw.githubusercontent.com/psyray/nmap-viewer/refs/heads/master/nmap-viewer.sh && \
+    chmod +x nmap-viewer.sh
+
+# Comment the start_application to avoid loop during image creation
+RUN sed -i '/# Start the application after installation/{n;s/^/# /}' nmap-viewer.sh
+
+
+# Install the app
+RUN echo "y" | ./nmap-viewer.sh install
+
+# Docker expose 3001
+EXPOSE 3001
+
+# start the app after the container creation
+CMD ["/bin/bash", "nmap-viewer.sh", "start"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ To install and run the Nmap Viewer application, follow these simple steps:
      ./nmap-viewer.sh update
      ```
 
+### With Docker
+1. Download the Dockerfile and build it
+
+   ```bash
+   docker build -t nmap-viewer . 
+   ```
+2. Create a container
+   ```bash
+   docker run -p 3001:3001 -d nmap-viewer 
+   ```
+3. Access it with http://localhost:3001
+
 ## Using the Application
 
 1. Open your web browser and navigate to `http://localhost:3001`.


### PR DESCRIPTION
Added a Dockerfile to containerize the nmap-viewer application. 
The Dockerfile automates the installation and configuration of the application while adjusting its behavior to prevent automatic startup after installation.

Changes Made:

Installed xdg-utils via apt.

Downloaded the nmap-viewer.sh script and granted execution permissions.

Modified the script to disable automatic startup after installation

Located the line # Start the application after installation and commented out the following line.

Exposed port 3001, which is used by the application.

Set the default command to start the application using /bin/bash nmap-viewer.sh start

Edit README

## Summary by Sourcery

Add a Dockerfile to containerize the nmap-viewer application, automate its installation, and update the README with Docker usage instructions.

New Features:
- Introduce a Dockerfile to containerize the nmap-viewer application, facilitating easier deployment and management.

Build:
- Add a Dockerfile that automates the installation and configuration of the nmap-viewer application, including the installation of xdg-utils and modification of the startup script.

Documentation:
- Update README to include instructions for building and running the nmap-viewer application using Docker.